### PR TITLE
Divided qrcode meta

### DIFF
--- a/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
+++ b/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
@@ -232,8 +232,8 @@ public class BarcodeScanner extends CordovaPlugin {
     public void onActivityResult(int requestCode, int resultCode, Intent intent) {
         if (requestCode == REQUEST_CODE && this.callbackContext != null) {
             if (resultCode == Activity.RESULT_OK) {
+                JSONObject obj = new JSONObject();
                 try {
-                    JSONObject obj = new JSONObject();
                     obj.put(TEXT, intent.getStringExtra("SCAN_RESULT"));
                     obj.put(FORMAT, intent.getStringExtra("SCAN_RESULT_FORMAT"));
                     obj.put(CANCELLED, false);
@@ -242,15 +242,13 @@ public class BarcodeScanner extends CordovaPlugin {
                     if (obj.get(FORMAT).equals("QR_CODE")) {
                         byte[] rawBytes = intent.getByteArrayExtra("SCAN_RESULT_BYTES");
                         JSONObject metaObj = this.extractDividedQrMetaData(rawBytes);
-                        // if (metaObj != null) {
                         obj.put(META, metaObj);
-                        // }
                     }
-                    this.callbackContext.success(obj);
                 } catch (JSONException e) {
                     Log.d(LOG_TAG, "This should never happen");
                 }
                 //this.success(new PluginResult(PluginResult.Status.OK, obj), this.callback);
+                this.callbackContext.success(obj);
             } else if (resultCode == Activity.RESULT_CANCELED) {
                 JSONObject obj = new JSONObject();
                 try {
@@ -354,12 +352,13 @@ public class BarcodeScanner extends CordovaPlugin {
      * @param rawBytes
      */
     private JSONObject extractDividedQrMetaData(byte[] rawBytes) {
+        // QR Code meta default value.
         int qrMetaMode = 0;
         int qrMetaPosition = QR_META_DEFAULT_VALUE_POSITION;
         int qrMetaTotal = QR_META_DEFAULT_VALUE_TOTAL;
         int qrMetaParity = QR_META_DEFAULT_VALUE_PARITY;
+        JSONObject obj = new JSONObject();
         try {
-            JSONObject obj = new JSONObject();
             qrMetaMode = (rawBytes[0] & NIBBLE_MASK_LOWER) >> 4;
             // If mode is "structured append"(3)
             if (qrMetaMode == STRUCTURED_APPEND) {
@@ -367,19 +366,14 @@ public class BarcodeScanner extends CordovaPlugin {
                 qrMetaTotal = ((rawBytes[1] & NIBBLE_MASK_LOWER) >> 4) + 1;
                 qrMetaParity = ((rawBytes[1] & NIBBLE_MASK_HIGHER) << 4) | ((rawBytes[2] & NIBBLE_MASK_LOWER) >> 4);
             }
-            // QRCode Mode
             obj.put(QR_MODE, qrMetaMode);
-            // QRCode Current No.(ex. 0..15)
             obj.put(POSITION, qrMetaPosition);
-            // divited QRCode total count.(up to 16)
             obj.put(TOTAL, qrMetaTotal);
-            // parity.
             obj.put(PARITY, qrMetaParity);
 
-            return obj;
         } catch (JSONException e) {
             Log.d(LOG_TAG, "This should never happen");
         }
-        return null;
+        return obj;
     }
 }

--- a/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
+++ b/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
@@ -43,6 +43,9 @@ public class BarcodeScanner extends CordovaPlugin {
     private static final String TEXT = "text";
     private static final String DATA = "data";
     private static final String TYPE = "type";
+    private static final String TOTAL = "total";
+    private static final String CURRENT = "current";
+    private static final String PARITY = "parity";
     private static final String PREFER_FRONTCAMERA = "preferFrontCamera";
     private static final String ORIENTATION = "orientation";
     private static final String SHOW_FLIP_CAMERA_BUTTON = "showFlipCameraButton";
@@ -223,6 +226,18 @@ public class BarcodeScanner extends CordovaPlugin {
                     obj.put(TEXT, intent.getStringExtra("SCAN_RESULT"));
                     obj.put(FORMAT, intent.getStringExtra("SCAN_RESULT_FORMAT"));
                     obj.put(CANCELLED, false);
+
+                    // Separated QRCode meta
+                    if (intent.getStringExtra("SCAN_RESULT_FORMAT").equals("QR_CODE")) {
+                        byte[] rawBytes = intent.getByteArrayExtra("SCAN_RESULT_BYTES");
+                        if ((rawBytes[0] & 0xf0) == 0x30) {
+                            obj.put(CURRENT, (rawBytes[0] & 0x0f));
+                            obj.put(TOTAL, ((rawBytes[1] & 0xf0) >> 4) + 1);
+                            obj.put(PARITY, ((rawBytes[1] & 0x0f) << 4) | ((rawBytes[2] & 0xf0) >> 4));
+
+                            Log.d(LOG_TAG, obj.toString());
+                        }
+                    }
                 } catch (JSONException e) {
                     Log.d(LOG_TAG, "This should never happen");
                 }

--- a/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
+++ b/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
@@ -352,11 +352,11 @@ public class BarcodeScanner extends CordovaPlugin {
                 JSONObject obj = new JSONObject();
                 // QRCode Mode (divided mode = 3)
                 obj.put(QR_MODE, (rawBytes[0] & 0xf0) >> 4);
-                // QRCode Current No.
+                // QRCode Current No.(ex. 0..15)
                 obj.put(CURRENT, (rawBytes[0] & 0x0f));
-                // divited QRCode total count.
+                // divited QRCode total count.(ex. 1..16)
                 obj.put(TOTAL, ((rawBytes[1] & 0xf0) >> 4) + 1);
-                // parity bit.
+                // parity.
                 obj.put(PARITY, ((rawBytes[1] & 0x0f) << 4) | ((rawBytes[2] & 0xf0) >> 4));
 
                 return obj;

--- a/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
+++ b/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
@@ -301,19 +301,19 @@ public class BarcodeScanner extends CordovaPlugin {
      *
      * @param requestCode The code to get request action
      */
-    public void requestPermissions(int requestCode)
-    {
-        PermissionHelper.requestPermissions(this, requestCode, permissions);
-    }
+   public void requestPermissions(int requestCode)
+   {
+       PermissionHelper.requestPermissions(this, requestCode, permissions);
+   }
 
    /**
-    * processes the result of permission request
-    *
-    * @param requestCode The code to get request action
-    * @param permissions The collection of permissions
-    * @param grantResults The result of grant
-    */
-   public void onRequestPermissionResult(int requestCode, String[] permissions,
+   * processes the result of permission request
+   *
+   * @param requestCode The code to get request action
+   * @param permissions The collection of permissions
+   * @param grantResults The result of grant
+   */
+  public void onRequestPermissionResult(int requestCode, String[] permissions,
                                          int[] grantResults) throws JSONException
    {
        PluginResult result;

--- a/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
+++ b/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
@@ -60,7 +60,7 @@ public class BarcodeScanner extends CordovaPlugin {
     // divided QR Code meta data.
     private static final String META = "meta";
     private static final String TOTAL = "total";
-    private static final String CURRENT = "current";
+    private static final String POSITION = "position";
     private static final String QR_MODE = "mode";
     private static final String PARITY = "parity";
 
@@ -123,9 +123,9 @@ public class BarcodeScanner extends CordovaPlugin {
 
             //android permission auto add
             if(!hasPermisssion()) {
-              requestPermissions(0);
+                requestPermissions(0);
             } else {
-              scan(args);
+                scan(args);
             }
         } else {
             return false;
@@ -344,22 +344,25 @@ public class BarcodeScanner extends CordovaPlugin {
      * QR Code can be One data symbol can be divided into up to 16 symbols.
      * It can be reconstructed as a single data symbol using
      * the same payload and the current No. / total Count.
-     * @param rawBytes The QRCode decoded raw byte data.
      */
     private JSONObject extractQrMetaData(byte[] rawBytes) {
         if ((rawBytes[0] & 0xf0) == 0x30) {
             try{
                 JSONObject obj = new JSONObject();
-                // QRCode Mode (divided mode = 3)
-                obj.put(QR_MODE, (rawBytes[0] & 0xf0) >> 4);
-                // QRCode Current No.(ex. 0..15)
-                obj.put(CURRENT, (rawBytes[0] & 0x0f));
-                // divited QRCode total count.(ex. 1..16)
-                obj.put(TOTAL, ((rawBytes[1] & 0xf0) >> 4) + 1);
-                // parity.
-                obj.put(PARITY, ((rawBytes[1] & 0x0f) << 4) | ((rawBytes[2] & 0xf0) >> 4));
+                // QRCode Mode
+                int mode = (rawBytes[0] & 0xf0) >> 4;
+                // mode=3: divided mode
+                if(mode == 3){
+                    obj.put(QR_MODE, mode);
+                    // QRCode Current No.(ex. 0..15)
+                    obj.put(POSITION, (rawBytes[0] & 0x0f));
+                    // divited QRCode total count.(up to 16)
+                    obj.put(TOTAL, ((rawBytes[1] & 0xf0) >> 4) + 1);
+                    // parity.
+                    obj.put(PARITY, ((rawBytes[1] & 0x0f) << 4) | ((rawBytes[2] & 0xf0) >> 4));
 
-                return obj;
+                    return obj;
+                }
             }catch(JSONException e){
                 Log.d(LOG_TAG, "This should never happen");
             }

--- a/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
+++ b/src/android/com/phonegap/plugins/barcodescanner/BarcodeScanner.java
@@ -58,8 +58,8 @@ public class BarcodeScanner extends CordovaPlugin {
     private static final String PHONE_TYPE = "PHONE_TYPE";
     private static final String SMS_TYPE = "SMS_TYPE";
     // divided QR Code meta data.
-    private static final String TOTAL = "total";
     private static final String META = "meta";
+    private static final String TOTAL = "total";
     private static final String CURRENT = "current";
     private static final String QR_MODE = "mode";
     private static final String PARITY = "parity";

--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -662,13 +662,13 @@ parentViewController:(UIViewController*)parentViewController
             CIQRCodeDescriptor *descriptor = (CIQRCodeDescriptor *)code.descriptor;
             Byte bytes[3];
             [descriptor.errorCorrectedPayload getBytes:bytes length:3];
-            // 構造的連接モード指示子(構造的連接 = 3）
+            // QRCode Mode (divided mode = 3)
             int qrmode = (bytes[0] & 0xf0) >> 4;
-            // 位置（0..15）
+            // QRCode Current No.(ex. 0..15)
             int current = bytes[0] & 0x0f;
-            // 全シンボル数
+            // divited QRCode total count.(ex. 1..16)
             int total = ((bytes[1] & 0xf0) >> 4) + 1;
-            // パリティデータ
+            // parity.
             int parity = ((bytes[1] & 0x0f) << 4) | ((bytes[2] & 0xf0) >>4);
 
             NSMutableDictionary* dict = [NSMutableDictionary new];

--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -420,7 +420,7 @@ parentViewController:(UIViewController*)parentViewController
 }
 
 //--------------------------------------------------------------------------
-- (void)barcodeScanSucceeded:(NSString*)text format:(NSString*)format meta:(NSMutableDictionary*)metaData {
+- (void)barcodeScanSucceeded:(NSString*)text format:(NSString*)format meta:(NSDictionary*)metaData {
     dispatch_sync(dispatch_get_main_queue(), ^{
         if (self.isSuccessBeepEnabled) {
             AudioServicesPlaySystemSound(_soundFileObject);

--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -652,9 +652,8 @@ parentViewController:(UIViewController*)parentViewController
 }
 
 //--------------------------------------------------------------------------
-// QR Code can be One data symbol can be divided into up to 16 symbols.
-// It can be reconstructed as a single data symbol using
-// the same payload and the position No. / total Count.
+// A single data symbol can be divided into up to 16 symbols in QR Code specification.
+// Divided symbols can be reconstructed as a single data symbol using the same payload , the position number and total count.
 //--------------------------------------------------------------------------
 - (NSDictionary*) extractQrMetaData:(AVMetadataMachineReadableCodeObject*)code {
     if (@available(iOS 11.0, *)) {
@@ -884,14 +883,14 @@ parentViewController:(UIViewController*)parentViewController
         return nil;
     }
 
-	self.overlayView.autoresizesSubviews = YES;
+    self.overlayView.autoresizesSubviews = YES;
     self.overlayView.autoresizingMask    = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.overlayView.opaque              = NO;
 
-	CGRect bounds = self.view.bounds;
+    CGRect bounds = self.view.bounds;
     bounds = CGRectMake(0, 0, bounds.size.width, bounds.size.height);
 
-	[self.overlayView setFrame:bounds];
+    [self.overlayView setFrame:bounds];
 
     return self.overlayView;
 }

--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -654,7 +654,7 @@ parentViewController:(UIViewController*)parentViewController
 //--------------------------------------------------------------------------
 // QR Code can be One data symbol can be divided into up to 16 symbols.
 // It can be reconstructed as a single data symbol using
-// the same payload and the current No. / total Count.
+// the same payload and the position No. / total Count.
 //--------------------------------------------------------------------------
 - (NSMutableDictionary*) extractQrMetaData:(AVMetadataMachineReadableCodeObject*)code {
     if (@available(iOS 11.0, *)) {
@@ -662,22 +662,25 @@ parentViewController:(UIViewController*)parentViewController
             CIQRCodeDescriptor *descriptor = (CIQRCodeDescriptor *)code.descriptor;
             Byte bytes[3];
             [descriptor.errorCorrectedPayload getBytes:bytes length:3];
-            // QRCode Mode (divided mode = 3)
+            // QRCode Mode
             int qrmode = (bytes[0] & 0xf0) >> 4;
-            // QRCode Current No.(ex. 0..15)
-            int current = bytes[0] & 0x0f;
-            // divited QRCode total count.(ex. 1..16)
-            int total = ((bytes[1] & 0xf0) >> 4) + 1;
-            // parity.
-            int parity = ((bytes[1] & 0x0f) << 4) | ((bytes[2] & 0xf0) >>4);
+            // mode=3: divided QRCode
+            if( qrmode == 3) {
+                // QRCode Position No.(ex. 0..15)
+                int position = bytes[0] & 0x0f;
+                // divited QRCode total count.(up to 16)
+                int total = ((bytes[1] & 0xf0) >> 4) + 1;
+                // parity.
+                int parity = ((bytes[1] & 0x0f) << 4) | ((bytes[2] & 0xf0) >>4);
 
-            NSMutableDictionary* dict = [NSMutableDictionary new];
-            dict[@"mode"] = [NSNumber numberWithInt:qrmode];
-            dict[@"current"] = [NSNumber numberWithInt:current];
-            dict[@"total"] = [NSNumber numberWithInt:total];
-            dict[@"parity"] = [NSNumber numberWithInt:parity];
+                NSMutableDictionary* dict = [NSMutableDictionary new];
+                dict[@"mode"] = [NSNumber numberWithInt:qrmode];
+                dict[@"position"] = [NSNumber numberWithInt:position];
+                dict[@"total"] = [NSNumber numberWithInt:total];
+                dict[@"parity"] = [NSNumber numberWithInt:parity];
 
-            return dict;
+                return dict;
+            }
         }
     }
     return nil;

--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -588,7 +588,7 @@ parentViewController:(UIViewController*)parentViewController
             AVMetadataMachineReadableCodeObject* code = (AVMetadataMachineReadableCodeObject*)[self.previewLayer transformedMetadataObjectForMetadataObject:(AVMetadataMachineReadableCodeObject*)metaData];
 
             if ([self checkResult:code.stringValue]) {
-                [self barcodeScanSucceeded:code.stringValue format:[self formatStringFromMetadata:code] meta:[self extractQrMetaData:code]];
+                [self barcodeScanSucceeded:code.stringValue format:[self formatStringFromMetadata:code] meta:[self extractDividedQrMetaData:code]];
             }
         }
     }
@@ -655,7 +655,7 @@ parentViewController:(UIViewController*)parentViewController
 // A single data symbol can be divided into up to 16 symbols in QR Code specification.
 // Divided symbols can be reconstructed as a single data symbol using the same payload , the position number and total count.
 //--------------------------------------------------------------------------
-- (NSDictionary*) extractQrMetaData:(AVMetadataMachineReadableCodeObject*)code {
+- (NSDictionary*) extractDividedQrMetaData:(AVMetadataMachineReadableCodeObject*)code {
     if (@available(iOS 11.0, *)) {
         if (code.type == AVMetadataObjectTypeQRCode){
             CIQRCodeDescriptor *descriptor = (CIQRCodeDescriptor *)code.descriptor;
@@ -883,14 +883,14 @@ parentViewController:(UIViewController*)parentViewController
         return nil;
     }
 
-    self.overlayView.autoresizesSubviews = YES;
+	self.overlayView.autoresizesSubviews = YES;
     self.overlayView.autoresizingMask    = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     self.overlayView.opaque              = NO;
 
-    CGRect bounds = self.view.bounds;
+	CGRect bounds = self.view.bounds;
     bounds = CGRectMake(0, 0, bounds.size.width, bounds.size.height);
 
-    [self.overlayView setFrame:bounds];
+	[self.overlayView setFrame:bounds];
 
     return self.overlayView;
 }

--- a/src/ios/CDVBarcodeScanner.mm
+++ b/src/ios/CDVBarcodeScanner.mm
@@ -40,7 +40,7 @@
 - (void)scan:(CDVInvokedUrlCommand*)command;
 - (void)encode:(CDVInvokedUrlCommand*)command;
 - (void)returnImage:(NSString*)filePath format:(NSString*)format callback:(NSString*)callback;
-- (void)returnSuccess:(NSString*)scannedText format:(NSString*)format cancelled:(BOOL)cancelled flipped:(BOOL)flipped meta:(NSMutableDictionary*)metaData  callback:(NSString*)callback;
+- (void)returnSuccess:(NSString*)scannedText format:(NSString*)format cancelled:(BOOL)cancelled flipped:(BOOL)flipped meta:(NSMutableDictionary*)metaData callback:(NSString*)callback;
 - (void)returnError:(NSString*)message callback:(NSString*)callback;
 @end
 


### PR DESCRIPTION
分割されたQRコードを複合化する際に必要となる情報を取得します。
QRコードより取得したデータより以下を取得、判定しての処理を追加。
1.  最初のシンボルキャラクタの上位4bitで表される数値が3の場合分割QRコードとして扱う
2.  続くデータでシンボルの位置、全分割数、パリティデータが取得できる
3. 分割情報が取得できた場合はレスポンスにmeta:{mode:n, position:n, total:n, parity:n}を追加する

分割QRコードでない場合は既存の返却値との変更は発生しません。

iOSでは上記情報を取得するためにversion.11以降が必要となります。
（現時点で全iOSの約95% v11が約9%, v12が約85%）